### PR TITLE
fix: GitHub OAuth 콜백 이중 호출로 인한 500 에러 수정

### DIFF
--- a/apps/web/src/features/auth/model/useGithubOAuthCallback.ts
+++ b/apps/web/src/features/auth/model/useGithubOAuthCallback.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { getCookie, setCookie } from 'cookies-next/client';
 import { toast } from 'sonner';
@@ -7,13 +7,10 @@ import { githubLoginCallbackAction } from '@/features/auth/api/githubLoginCallba
 import { ACCESS_TOKEN_KEY } from '@/features/auth/model/constants';
 import { ROUTES } from '@/shared/routes/routes';
 
-/**
- * GitHub OAuth 콜백 처리를 담당하는 훅
- * @returns void
- */
 export function useGithubOAuthCallback() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const hasCalled = useRef(false);
 
   const code = searchParams.get('code');
   const state = searchParams.get('state');
@@ -26,6 +23,9 @@ export function useGithubOAuthCallback() {
       router.replace(ROUTES.HOME);
       return;
     }
+
+    if (hasCalled.current) return;
+    hasCalled.current = true;
 
     try {
       const response = await githubLoginCallbackAction({ code });
@@ -48,5 +48,5 @@ export function useGithubOAuthCallback() {
     } else {
       handleGithubCallback();
     }
-  }, [handleGithubCallback, router, searchParams, state]);
+  }, [handleGithubCallback, router, state]);
 }


### PR DESCRIPTION
## Summary

- `useGithubOAuthCallback`에서 `router.replace()` 호출 후 라우터 참조가 변경되어 `useEffect`가 재실행되고, 이미 사용된 GitHub OAuth code로 서버 액션이 재호출되는 이중 호출 버그 수정
- `hasCalled` ref를 추가하여 `githubLoginCallbackAction` 중복 실행 방지
- `useEffect` 의존성에서 중복된 `searchParams` 제거 (`code`, `state`는 이미 `handleGithubCallback` 내부에 캡처됨)

## Root Cause

Vercel 런타임 로그에서 `POST /auth/github/callback 500` 에러가 쌍으로 발생 (약 14초 간격):
- `router.replace(state)` 호출 → 라우터 객체 참조 변경 → `useCallback` 새 함수 생성 → `useEffect` 재실행 → 동일 code 재사용 → GitHub에서 거부 → 500

## Test plan

- [ ] GitHub OAuth 로그인 정상 동작 확인
- [ ] 로그인 성공 후 원래 페이지로 리다이렉트 확인
- [ ] Vercel 로그에서 `generateAccessToken Error` 500 에러 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)