### PR TITLE
fix: 북마크 파비콘 표시 안되는 문제 수정

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -12,10 +12,11 @@ export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="ko" suppressHydrationWarning>
       <head>
-        <link rel="apple-touch-icon" href="touch-icon-iphone.png" />
-        <link rel="apple-touch-icon" sizes="152x152" href="touch-icon-ipad.png" />
-        <link rel="apple-touch-icon" sizes="167x167" href="touch-icon-ipad-retina.png" />
-        <link rel="apple-touch-icon" sizes="180x180" href="touch-icon-iphone-retina.png" />
+        <link rel="apple-touch-icon" href="/favicon/apple-icon.png" />
+        <link rel="apple-touch-icon" sizes="76x76" href="/favicon/apple-icon-76x76.png" />
+        <link rel="apple-touch-icon" sizes="152x152" href="/favicon/apple-icon-152x152.png" />
+        <link rel="apple-touch-icon" sizes="167x167" href="/favicon/apple-icon-152x152.png" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-icon-180x180.png" />
       </head>
       <body className={classnames(pretendard.className)} suppressHydrationWarning>
         <Provider>

--- a/apps/web/src/shared/model/metadata.ts
+++ b/apps/web/src/shared/model/metadata.ts
@@ -31,7 +31,7 @@ export const generateRootMetadata = (): Metadata => {
       shortcut: '/favicon/apple-icon.png',
       apple: '/favicon/apple-icon.png',
       other: {
-        rel: '/favicon/apple-icon-precomposed',
+        rel: 'apple-touch-icon-precomposed',
         url: '/favicon/apple-icon-precomposed.png',
       },
     },


### PR DESCRIPTION
## Summary

- `layout.tsx`의 `apple-touch-icon` 링크들이 존재하지 않는 파일(`touch-icon-iphone.png` 등)을 참조하고 있어 404 발생 → `public/favicon/` 하위 실제 파일 경로로 수정
- `metadata.ts`의 `icons.other.rel` 값이 파일 경로(`/favicon/apple-icon-precomposed`)로 잘못 설정되어 있던 것을 올바른 링크 관계 타입(`apple-touch-icon-precomposed`)으로 수정

## Test plan

- [ ] 브라우저에서 북마크 추가 시 파비콘이 정상 표시되는지 확인
- [ ] iOS Safari에서 홈 화면 추가 시 아이콘 정상 표시 확인